### PR TITLE
Missing hVd diphthongs

### DIFF
--- a/apitools/austalk-select-hVd-words.py
+++ b/apitools/austalk-select-hVd-words.py
@@ -47,8 +47,8 @@ WHERE {
  """ % speakerid
 
     hVdWords = {
-        'monopthongs': ['head', 'had', 'hud', 'heed', 'hid', 'hood', 'hod', "whod"],
-        'dipthongs': ['herd', 'howd', 'hoyd', 'haired', 'hard', 'heared']
+        'monopthongs': ['head', 'had', 'hud', 'heed', 'hid', 'hood', 'hod', 'whod', 'herd', 'haired', 'hard', 'horde'],
+        'dipthongs': ['howd', 'hoyd', 'hide', 'hode', 'hade', 'heared'] 
         }
 
     if words == 'all':


### PR DESCRIPTION
Four hVd words were missing (hide, hode, horde, hade) as per Cox 2012: "The /hVd/ frame includes the 18 words heed, hid, head, had, hard, hud, hod, horde, hood, who’d, heard, hide, hade, hoyd, howd,
hode, heered, haired."

Note that I read that Cox also described these sets as 12 monophthongs and 6 diphthongs, but I've not found an explicit list of which is which. I'm guessing that most hVrd words will be considered monophthongs for Australian English, as per http://clas.mq.edu.au/speech/phonetics/phonetics/vowelgraphs/AusE_Monophthongs.html.
http://clas.mq.edu.au/speech/phonetics/phonetics/vowelgraphs/AusE_Diphthongs.html
From these sources, I'm stuck on 'heared', but if we look at the Austalk Annotation report (2014), all six of the diphthongs I've listed are transcribed with two vowels:
* howd, hoyd, hide, hode, hade, heared
whilst six words were transcribed with one vowel:
* 'head', 'had', 'hud', 'hid', 'hood', 'hod'
with six vowels also taking the IPA lengthening symbol (ː):
* 'heed', 'herd', 'haired', 'hard', 'horde', 'whod'

I believe that these last 12 should be considered monophthongs.